### PR TITLE
grafik file pressemitteilungen

### DIFF
--- a/03_grundlagen-der-statistik.Rmd
+++ b/03_grundlagen-der-statistik.Rmd
@@ -186,13 +186,7 @@ quiz(caption = "Fragen zur Pressemitteilung",
 
 <p>
 <center>
-![*Quelle: <https://www.destatis.de/DE/Presse/Pressemitteilungen/2021/07/PD21_N045_639.html>*](https://github.com/CorrelAid/rlernen_umwelt/blob/main/abbildungen/08_grundlagen-der-statistik/vebraucher:innenpreise_pkw.png?raw=true){#id .class width=100%}
-</center>
-</p>
-
-<p>
-<center>
-![*Quelle: <https://www.destatis.de/DE/Presse/Pressemitteilungen/2021/07/PD21_N045_639.html>*](https://github.com/CorrelAid/rlernen_umwelt/blob/main/abbildungen/08_grundlagen-der-statistik/vebraucher:innenpreise_bahn.png?raw=true){#id .class width=100%}
+![*Quelle: <https://www.destatis.de/DE/Presse/Pressemitteilungen/2021/07/PD21_N045_639.html>*](https://github.com/CorrelAid/rlernen_umwelt/blob/main/abbildungen/08_grundlagen-der-statistik/verbraucherinnenpreise_pkw.png?raw=true){#id .class width=100%}
 </center>
 </p>
 


### PR DESCRIPTION
grafiken waren zuvor nicht in der repo hinterlegt, link daher fehlermeldung. neuer link ruft die entsprechenden grafiken ab.